### PR TITLE
Enable in-context translation support

### DIFF
--- a/lib/open_project/translations/engine.rb
+++ b/lib/open_project/translations/engine.rb
@@ -26,10 +26,18 @@ module OpenProject::Translations
              :author_url => 'https://openproject.org',
              :requires_openproject => '>= 4.0.0'
 
+    patches [ :ApplicationHelper ]
+
     config.to_prepare do
+      # the patches helper does not work for patches in the Redmine module, so we patch things manually now
       Redmine::I18n # let rails do some autoloading magic with Redmine::I18n
       require_dependency 'open_project/translations/patches'
       require_dependency 'open_project/translations/patches/redmine_i18n_patch'
+    end
+
+    initializer 'translations.hooks' do
+      require_dependency 'open_project/translations/hooks'
+      require_dependency 'open_project/translations/hooks/crowdin_in_context_translation_hook'
     end
   end
 end

--- a/lib/open_project/translations/hooks.rb
+++ b/lib/open_project/translations/hooks.rb
@@ -12,11 +12,7 @@
 # See doc/COPYRIGHT.md for more details.
 #++
 
-module OpenProject
-  module Translations
-    IN_CONTEXT_TRANSLATION_CODE = 'lol'
-    IN_CONTEXT_TRANSLATION_NAME = 'In-Context Crowdin Translation'
-
-    require "open_project/translations/engine"
+module OpenProject::Translations
+  module Hooks
   end
 end

--- a/lib/open_project/translations/hooks/crowdin_in_context_translation_hook.rb
+++ b/lib/open_project/translations/hooks/crowdin_in_context_translation_hook.rb
@@ -12,11 +12,16 @@
 # See doc/COPYRIGHT.md for more details.
 #++
 
-module OpenProject
-  module Translations
-    IN_CONTEXT_TRANSLATION_CODE = 'lol'
-    IN_CONTEXT_TRANSLATION_NAME = 'In-Context Crowdin Translation'
-
-    require "open_project/translations/engine"
+module OpenProject::Translations::Hooks
+  class CrowdinInContextTranslations < Redmine::Hook::ViewListener
+    def view_layouts_base_html_head(context)
+      if ::I18n.locale == :lol #the in-context translation pseudo-language
+        "<script type=\"text/javascript\">
+           var _jipt = [];
+           _jipt.push(['project', 'openproject']);
+         </script>
+         <script type=\"text/javascript\" src=\"//cdn.crowdin.com/jipt/jipt.js\"></script>".html_safe
+      end
+    end
   end
 end

--- a/lib/open_project/translations/patches/application_helper_patch.rb
+++ b/lib/open_project/translations/patches/application_helper_patch.rb
@@ -1,0 +1,52 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.md for more details.
+#++
+
+require_dependency 'application_helper'
+
+module OpenProject::Translations::Patches
+  module ApplicationHelperPatch
+    def self.included(base)
+      base.class_eval do
+        def all_lang_options_for_select_with_translation_plugin(blank=true)
+          lang_options = all_lang_options_for_select_without_translation_plugin(blank)
+
+          # rename in-context translation language name for the language select box
+          lang_options.map do |lang_name, lang_code|
+            if lang_code == OpenProject::Translations::IN_CONTEXT_TRANSLATION_CODE &&
+               ::I18n.locale != OpenProject::Translations::IN_CONTEXT_TRANSLATION_CODE
+              [OpenProject::Translations::IN_CONTEXT_TRANSLATION_NAME, lang_code]
+            else
+              [lang_name, lang_code]
+            end
+          end
+        end
+        alias_method_chain :all_lang_options_for_select, :translation_plugin
+
+        def lang_options_for_select_with_translation_plugin(blank=true)
+          lang_options = lang_options_for_select_without_translation_plugin(blank)
+          # rename in-context translation language name for the language select box
+          lang_options.map do |lang_name, lang_code|
+            if lang_code == OpenProject::Translations::IN_CONTEXT_TRANSLATION_CODE &&
+               ::I18n.locale != OpenProject::Translations::IN_CONTEXT_TRANSLATION_CODE
+              [OpenProject::Translations::IN_CONTEXT_TRANSLATION_NAME, lang_code]
+            else
+              [lang_name, lang_code]
+            end
+          end
+        end
+        alias_method_chain :lang_options_for_select, :translation_plugin
+      end
+    end
+  end
+end

--- a/lib/open_project/translations/patches/redmine_i18n_patch.rb
+++ b/lib/open_project/translations/patches/redmine_i18n_patch.rb
@@ -14,11 +14,19 @@
 
 module Redmine
   module I18n
-     def all_languages_with_translation_plugin
-      all_languages_without_translation_plugin +
-        Dir[OpenProject::Translations::Engine.root.join('config', 'locales', '*.{rb,yml}').to_s].map do |f|
-          File.basename(f).split('.').first.to_sym
-        end
+
+    # Add langauges from this plugin to the list of available languages
+    def all_languages_with_translation_plugin
+      plugin_languages = Dir[OpenProject::Translations::Engine.root.join('config', 'locales', '*.{rb,yml}').to_s].map do |file_path|
+        File.basename(file_path).split('.').first.to_sym
+      end
+
+      # do not count javascript translations as separate langauges
+      plugin_languages.reject! {|l| l.to_s[0..2] == 'js-' }
+
+      core_languages = all_languages_without_translation_plugin
+
+      (core_languages + plugin_languages).sort.uniq
     end
     alias_method_chain :all_languages, :translation_plugin
   end


### PR DESCRIPTION
Crowdin offers a feature to translate an application within the application itself. This PR aims to enable this with OpenProject.

There are still two bugs (which is why this is a WIP at the moment):
- [x] The crowdin in-context localization only works for the first dev-serve request
- [x] The crowdin language has a wierd name in the language-select box in the user settings
