### PR TITLE
Update docu to specify rails env

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then update your bundle with the following commands executed from your openproje
 
 <pre>
 bundle install
-bundle exec rake assets:precompile
+RAILS_ENV=production bundle exec rake assets:precompile
 </pre>
 
 and restart the OpenProject server.


### PR DESCRIPTION
If the production env is not specified, asset precompilation will lead to the refs within e.g stylesheets and js to other resources not containing the digest, which is then an invalid link.
