### PR TITLE
Retry checkout with longer format

### DIFF
--- a/lib/open_project/translations/helpers/run_command.rb
+++ b/lib/open_project/translations/helpers/run_command.rb
@@ -4,8 +4,9 @@ module RunCommand
   def run_command(command)
     shell = Mixlib::ShellOut.new(command)
     shell.run_command
-    raise "The following command returned an error: #{command}" if shell.error? &&
-      !(shell.stdout =~ /nothing to commit/)
+    if shell.error? && !(shell.stdout =~ /nothing to commit/)
+      raise "The following command returned an error: #{command}. Error message: #{shell.stderr}"
+    end
 
     shell.stdout.gsub(/\n$/, '')
   end

--- a/lib/open_project/translations/models/git_repository.rb
+++ b/lib/open_project/translations/models/git_repository.rb
@@ -16,10 +16,14 @@ class GitRepository
     within_repo do
       begin
         run_command "git checkout --force '#{ref}' --"
-      rescue
-        # old git versions get distracted by '--' at the end and this shortcut
-        # does not work anymore
-        run_command "git checkout --force -b '#{ref}' --track 'origin/#{ref}'"
+      rescue Exception => e
+        if e.message =~ /fatal: invalid reference/
+          # old git versions get distracted by '--' at the end and this shortcut
+          # does not work anymore
+          run_command "git checkout --force -b '#{ref}' --track 'origin/#{ref}'"
+        else
+          raise e
+        end
       end
     end
   end

--- a/lib/open_project/translations/models/git_repository.rb
+++ b/lib/open_project/translations/models/git_repository.rb
@@ -14,7 +14,13 @@ class GitRepository
 
   def checkout(ref)
     within_repo do
-      run_command "git checkout --force '#{ref}' --"
+      begin
+        run_command "git checkout --force '#{ref}' --"
+      rescue
+        # old git versions get distracted by '--' at the end and this shortcut
+        # does not work anymore
+        run_command "git checkout --force -b '#{ref}' --track 'origin/#{ref}'"
+      end
     end
   end
 

--- a/lib/open_project/translations/models/git_repository.rb
+++ b/lib/open_project/translations/models/git_repository.rb
@@ -16,7 +16,7 @@ class GitRepository
     within_repo do
       begin
         run_command "git checkout --force '#{ref}' --"
-      rescue Exception => e
+      rescue StandardError => e
         if e.message =~ /fatal: invalid reference/
           # old git versions get distracted by '--' at the end and this shortcut
           # does not work anymore


### PR DESCRIPTION
Older git versions of git seem to get distracted when you add -- at the end. The shortcut for checking out remote branches does not seem to work anymore. So we try again with the long format. 
