### PR TITLE
handle missing :many key in easter european l18n files

### DIFF
--- a/lib/open_project/translations/engine.rb
+++ b/lib/open_project/translations/engine.rb
@@ -29,8 +29,8 @@ module OpenProject::Translations
     # load custom translation rules, as stored in config/locales/plurals.rb
     # to be aware of e.g. Japanese not having a plural from for nouns
     initializer 'translation.pluralization.rules' do
-      require 'i18n/backend/pluralization'
-      I18n::Backend::Simple.send(:include, I18n::Backend::Pluralization)
+      require 'open_project/translations/pluralization_backend'
+      I18n::Backend::Simple.send(:include, OpenProject::Translations::PluralizationBackend)
     end
 
     config.to_prepare do

--- a/lib/open_project/translations/pluralization_backend.rb
+++ b/lib/open_project/translations/pluralization_backend.rb
@@ -1,0 +1,47 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.md for more details.
+#++
+
+# Extends the default pluralizer I18n::Backend::Pluralization
+# to be more resiliant with regards to a missing :many key in
+# the l10n files of some eastern european languages
+# (e.g. Russian, Hungarian, Polish)
+
+require 'i18n/backend/pluralization'
+
+module OpenProject
+  module Translations
+    module PluralizationBackend
+      include I18n::Backend::Pluralization
+
+      def pluralize(locale, entry, count)
+        super
+      rescue ::I18n::InvalidPluralizationData
+        pluralizer = pluralizer(locale)
+        if pluralizer.respond_to?(:call)
+          key = if count.zero? && entry.key?(:zero)
+                  :zero
+                else
+                  pluralizer.call(count)
+                end
+
+          if key == :many && entry.key?(:other)
+            entry[:other]
+          else
+            raise
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
For whatever reasons, a lot of eastern European languages like Russian, Polish and Hungarian do not have a :many localization when their pluralization rule states that there is a many case for noun pluralization. We fallback to the :other case then hoping to not be too far off.


https://community.openproject.com/projects/openproject/work_packages/25425